### PR TITLE
roave/security-advisories belongs in require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "guzzlehttp/psr7": "^1.3 || ^1.4",
     "psr/http-server-middleware": "^1.0",
     "psr/container": "^1.0",
-    "zendframework/zend-stratigility": "^3.0",
-    "roave/security-advisories": "dev-master"
+    "zendframework/zend-stratigility": "^3.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.3",
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "^7.0",
+    "roave/security-advisories": "dev-master"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Could you please make an new release with this change?

Having the SecurityAdvisories in the `require` section prevents anyone using your package from not using SecurityAdvisories even temporary.

See https://github.com/Roave/SecurityAdvisories#installation