### PR TITLE
PHP 8 Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 php:
-  - 7.1
-  - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
 
 before_install:
   - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![License](https://poser.pugx.org/oras/monolog-middleware/license)](https://packagist.org/packages/oras/monolog-middleware)
 
 # Monolog Logger Middleware
-Monolog Middleware to be used with PSR-7 middleware frameworks like Zend Expressive and Slim.
+Monolog Middleware to be used with PSR-7 middleware frameworks like mezzio (formerly Zend Expressive) and Slim.
 
-**Now it does support Zend Expressive `3.*`**
+**Now it does support mezzio `3.*`**
 
 To use with Zend Expressive `1.*` please install version `1.1.4`
 To use with Zend Expressive `2.*` please install version `2.0.0`
@@ -23,7 +23,7 @@ To use with Zend Expressive `2.*` please install version `2.0.0`
 composer require oras/monolog-middleware
 ```
 ##### 2) Add configuration
-Then in your Zend Expressive `config/autoload/` directory, created a new config file call it: `logger.local.php`
+Then in your mezzio `config/autoload/` directory, created a new config file call it: `logger.local.php`
 
 As a starting point, you can have the following in the file:
 
@@ -83,7 +83,7 @@ Please refer to Loggables list at end for all possible variables.
 
 
 ### Requirements
-- PHP >= 7.1
+- PHP >= 7.3
 
 
 ### Configuration examples

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,17 @@
     }
   ],
   "require": {
-    "monolog/monolog": "^1.19",
-    "psr/http-message": "~1.0.0",
-    "symfony/http-foundation": "^3.0",
-    "guzzlehttp/psr7": "^1.3 || ^1.4",
     "php": "^7.3 || ^7.4 || ^8.0",
+    "monolog/monolog": "^2.2",
+    "psr/http-message": "^1.0",
+    "symfony/http-foundation": "^5.3",
+    "guzzlehttp/psr7": "^1.8",
     "psr/http-server-middleware": "^1.0",
-    "psr/container": "^1.0",
-    "zendframework/zend-stratigility": "^3.0"
+    "psr/container": "^2.0",
+    "laminas/laminas-stratigility": "^3.3"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "^2.3",
+    "squizlabs/php_codesniffer": "^3.6",
     "phpunit/phpunit": "^9.5",
     "roave/security-advisories": "dev-master"
   },

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     }
   ],
   "require": {
-    "php": "^7.1 || ^7.2",
     "monolog/monolog": "^1.19",
     "psr/http-message": "~1.0.0",
     "symfony/http-foundation": "^3.0",
     "guzzlehttp/psr7": "^1.3 || ^1.4",
+    "php": "^7.3 || ^7.4 || ^8.0",
     "psr/http-server-middleware": "^1.0",
     "psr/container": "^1.0",
     "zendframework/zend-stratigility": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.3",
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^9.5",
     "roave/security-advisories": "dev-master"
   },
   "autoload": {

--- a/src/MonologMiddleware/Test/Factory/MonologMiddlewareFactoryTest.php
+++ b/src/MonologMiddleware/Test/Factory/MonologMiddlewareFactoryTest.php
@@ -9,7 +9,7 @@ class MonologMiddlewareFactoryTest extends TestCase
 {
     protected $serviceContainer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $monologArray = [
             'monolog' =>


### PR DESCRIPTION
Hi @orasik 

would you consider a new release based on this pull request?

- enable support for PHP 8, raised the PHP requirements to the latest supported versions (7.3 - 8.0) 
- replaced deprecated `zendframework/zend-stratigility` with successor `laminas/laminas-stratigility`
- upgraded all dependencies to the latest versions
- fixed one test case because the new `phpunit 9` was complaining

Things that might need improvement:

- `phpunit 9` complains about two test cases without any assert's being called
- documentation: I just replaced mentions of Zend Expressive with its successor mezzio
- `travis.yml`: I have no way of testing my changes at the moment
- I think you could drop the reference to `laminas/laminas-stratigility` in `composer.json` because I found no reference of the former `zendframework` namespace in your code.

Cheers, Stefan